### PR TITLE
Fix 'upload to existing directory' bug

### DIFF
--- a/public/dir.js
+++ b/public/dir.js
@@ -176,19 +176,18 @@
 							var data = JSON.parse( ajax.responseText );
 							form.classList.add( data.success == true ? 'is-success' : 'is-error' );
               data.dir = data.dir.includes('\\') ? data.dir.split('\\').join('/') : data.dir;
-              if (!content) {
+
                 // document.getElementsByClassName('box__input')[0].innerHTML = '';
                 document.querySelector('.box__message').innerHTML = "Uploaded to <a href='/dir/" + data.dir + '#' + hash + "'>" + data.dir + '#' + hash + "</a>. Do not lose this link, or the uploaded files will never be found again!";
                 //Gian: forcing a page refresh (which will not happen after the insertion of the hash).
                 document.querySelector('.box__message > a').addEventListener('click', (e) => {
-                  if (!window.location.hash) {
-                    window.location.href += '#' + hash;
-                  }
                   window.location.reload();
                 });
-              } else {
+                if (!window.location.hash) {
+                  window.location.href += '#' + hash;
+                }
                 listingFiles();
-              }
+
 							if( !data.success ) errorMsg.textContent = data.error;
 						}
 						else alert( 'Error. Please, contact the webmaster!' );

--- a/public/dir.js
+++ b/public/dir.js
@@ -1,5 +1,54 @@
   'use strict';
 
+  //TODO: avoid global variables...
+  let content = ''; //list of uploaded files.
+
+  //Functions for handling file decryption:
+  const handleFileDownload = (e) => {
+    e.preventDefault;
+    let currentLink = e.currentTarget;
+    if (currentLink.href.includes('/dir')) { //Gian: I'm only decrypting a file once...
+      currentLink.setAttribute('download', currentLink.innerText);
+      const filePath = (window.location.href.replace(location.hash, '')).replace('/dir', '/cat') + '/' + currentLink.innerText;
+      fetch(filePath)
+      .then(res => res.blob())
+      .then(blob => decryptFile(blob))
+      .then(downloadLink => {
+        currentLink.setAttribute('href', downloadLink);
+        currentLink.click();
+      });
+    }
+  };
+
+  const addFilesDecrypt = () => {
+    const fileItems = document.getElementById('ls').firstElementChild.children;
+    for (let file of fileItems) {
+      file.firstElementChild.setAttribute('href', window.location.hash);
+      file.firstElementChild.setAttribute('download', file.firstElementChild.innerText);
+      //Gian: I'm only decrypting files that are explicitly selected:
+      file.firstElementChild.addEventListener('click', handleFileDownload);
+    }
+  }
+
+  //Listing uploaded files:
+  const listingFiles = () => {
+    content = '';
+    fetch((window.location+ '').replace("dir","ls"))
+      .then(response => response.json())
+      .catch(error => console.error('Error:', error))
+      .then(files => {
+        files.forEach(file => {
+          content += '<li><a href="">'+file+'</a></li>';
+        });
+        document.getElementById('ls').innerHTML = '<ul>' + content + '</ul>';
+        // if (content) {
+        //   //Gian: Doing this to prevent user from breaking the app. Right now we cannot handle new files being uploaded under the same key.
+        //   document.getElementsByClassName('box__input')[0].innerHTML = '';
+        // }
+        addFilesDecrypt();
+      });
+  }
+
 	;( function ( document, window, index )
 	{
 		// feature detection for drag&drop upload
@@ -126,19 +175,20 @@
 						{
 							var data = JSON.parse( ajax.responseText );
 							form.classList.add( data.success == true ? 'is-success' : 'is-error' );
-							// document.querySelector('.box__message').innerHTML = "Uploaded to <a href='/dir/" + data.dir + "'>" + data.dir + "</a>. Do not lose this link, or the uploaded files will never be found again!";
-              // const sep = data.dir.includes('/') ? '/' : '\\';
-              console.log(data.dir);
               data.dir = data.dir.includes('\\') ? data.dir.split('\\').join('/') : data.dir;
-              console.log(data.dir);
-              // document.querySelector('.box__message').innerHTML = "Uploaded to <a href='" + sep + 'dir' + sep + data.dir + '#' + hash + "'>" + data.dir + '#' + hash + "</a>. Do not lose this link, or the uploaded files will never be found again!";
-							document.querySelector('.box__message').innerHTML = "Uploaded to <a href='/dir/" + data.dir + '#' + hash + "'>" + data.dir + '#' + hash + "</a>. Do not lose this link, or the uploaded files will never be found again!";
-              //Gian: forcing a page refresh (which will not happen after the insertion of the hash).
-              document.querySelector('.box__message > a').addEventListener('click', (e) => {
-                // console.log(window.location.href);
-                window.location.href += '#' + hash;
-                window.location.reload();
-              });
+              if (!content) {
+                // document.getElementsByClassName('box__input')[0].innerHTML = '';
+                document.querySelector('.box__message').innerHTML = "Uploaded to <a href='/dir/" + data.dir + '#' + hash + "'>" + data.dir + '#' + hash + "</a>. Do not lose this link, or the uploaded files will never be found again!";
+                //Gian: forcing a page refresh (which will not happen after the insertion of the hash).
+                document.querySelector('.box__message > a').addEventListener('click', (e) => {
+                  if (!window.location.hash) {
+                    window.location.href += '#' + hash;
+                  }
+                  window.location.reload();
+                });
+              } else {
+                listingFiles();
+              }
 							if( !data.success ) errorMsg.textContent = data.error;
 						}
 						else alert( 'Error. Please, contact the webmaster!' );
@@ -150,9 +200,14 @@
 						alert( 'Error. Please, try again!' );
 					};
 
-          let hash = '';
-          encryptFiles(ajaxData.getAll(input.getAttribute('name'))).then(([encryptedFiles, keyCipher]) => {
-            hash = keyCipher;
+          let hash = window.location.hash ? window.location.hash.slice(1) : '';
+          console.log(hash);
+          encryptFiles([
+            ajaxData.getAll(input.getAttribute('name')),
+            hash
+          ])
+          .then(([encryptedFiles, hashKey]) => {
+            hash = hashKey;
             ajaxData.delete(input.getAttribute( 'name' ));
             for (const [name, value] of Object.entries(encryptedFiles)) {
               ajaxData.append( input.getAttribute( 'name' ), value, name );
@@ -205,45 +260,5 @@
 	}( document, window, 0 ));
 
     if (window.location.pathname !== '/dir') {
-    	fetch((window.location+ '').replace("dir","ls"))
-    		.then(response => response.json())
-    		.catch(error => console.error('Error:', error))
-    		.then(files => {
-    			var content = '';
-    			files.forEach(file => {
-    				content += '<li><a href="">'+file+'</a></li>';
-    			});
-    			document.getElementById('ls').innerHTML = '<ul>' + content + '</ul>';
-          if (content) {
-            //Gian: Doing this to prevent user from breaking the app. Right now we cannot handle new files being uploaded under the same key.
-            document.getElementsByClassName('box__input')[0].innerHTML = '';            
-          }
-          addFilesDecrypt();
-    		});
-
-        const handleFileDownload = (e) => {
-          e.preventDefault;
-          let currentLink = e.currentTarget;
-          if (currentLink.href.includes('/dir')) { //Gian: I'm only decrypting a file once...
-            currentLink.setAttribute('download', currentLink.innerText);
-            const filePath = (window.location.href.replace(location.hash, '')).replace('/dir', '/cat') + '/' + currentLink.innerText;
-            fetch(filePath)
-            .then(res => res.blob())
-            .then(blob => decryptFile(blob))
-            .then(downloadLink => {
-              currentLink.setAttribute('href', downloadLink);
-              currentLink.click();
-            });
-          }
-        };
-
-        const addFilesDecrypt = () => {
-          const fileItems = document.getElementById('ls').firstElementChild.children;
-          for (let file of fileItems) {
-            file.firstElementChild.setAttribute('href', window.location.hash);
-            file.firstElementChild.setAttribute('download', file.firstElementChild.innerText);
-            //Gian: I'm only decrypting files that are explicitly selected:
-            file.firstElementChild.addEventListener('click', handleFileDownload);
-          }
-        }
+      listingFiles();
     }


### PR DESCRIPTION
# Bug Fixes:

## Upload to existing directory. 

**Bug**: After creating a secure directory (with its unique key), the app could not handle upload requests of new files on that same directory - trying to do so would cause errors when trying to decrypt the original files (the first ones to be uploaded). In other words, after the directory was created, with a certain number of files inside of it, it was also 'locked' and new files could not be added.

**Cause**: `dir.js` (originally from `dir.html`) and the cipher itself (`cipher.js`) weren't ready for the feature, so their response to a use case of 'upload more files to an existing directory' would be to just create a new (hidden) directory with the new files in it. 

**Where**: `dir.js` and `cipher.js`.

**Solution**: Modifying `dir.js` and `cipher.js` to handle this specific use case. The changes on `cipher.js` where really straightforward (basically just receiving an additional `hashKey` argument and conditioning the encryption according to its value), `dir.js` needed a little bit more work in order to create the operational flow I was looking for.
